### PR TITLE
Fix parsing of dictionary values that contain ":"

### DIFF
--- a/edit/buildozer.go
+++ b/edit/buildozer.go
@@ -514,7 +514,7 @@ func cmdDictAdd(opts *Options, env CmdEnvironment) (*build.File, error) {
 	}
 
 	for _, x := range args {
-		kv := strings.Split(x, ":")
+		kv := strings.SplitN(x, ":", 2)
 		expr := getStringExpr(kv[1], env.Pkg)
 
 		prev := DictionaryGet(dict, kv[0])
@@ -539,7 +539,7 @@ func cmdDictSet(opts *Options, env CmdEnvironment) (*build.File, error) {
 	}
 
 	for _, x := range args {
-		kv := strings.Split(x, ":")
+		kv := strings.SplitN(x, ":", 2)
 		expr := getStringExpr(kv[1], env.Pkg)
 		// Set overwrites previous values.
 		DictionarySet(dict, kv[0], expr)


### PR DESCRIPTION
If a dictionary value contains a `:`, then the value is not correct.  Need to preserve everything after the first `:`.  One example where this comes up is setting environment variables for paths when using `container_image` from the docker rules.